### PR TITLE
Fix Australian Federal Register title counts

### DIFF
--- a/sources/AU/FederalRegister/bootstrap.py
+++ b/sources/AU/FederalRegister/bootstrap.py
@@ -138,20 +138,18 @@ class AustraliaFederalRegisterScraper(BaseScraper):
 
     def _get_total_count(self, filter_str: str = None) -> int:
         """Get total count of titles matching the filter."""
-        try:
-            self.rate_limiter.wait()
+        self.rate_limiter.wait()
 
-            url = "/v1/titles/$count"
-            if filter_str:
-                url += f"?$filter={filter_str}"
-
-            resp = self.client.get(url)
-            resp.raise_for_status()
-            return int(resp.text.strip())
-
-        except Exception as e:
-            logger.error(f"Failed to get title count: {e}")
-            return 0
+        query = "$top=1&$skip=0&$count=true"
+        if filter_str:
+            query += f"&$filter={filter_str}"
+        resp = self.client.get(f"/v1/titles?{query}")
+        resp.raise_for_status()
+        payload = resp.json()
+        count = payload.get("@odata.count")
+        if isinstance(count, bool) or not isinstance(count, int) or count < 0:
+            raise ValueError("Australian title response has no valid @odata.count")
+        return count
 
     def _get_latest_version(self, title_id: str) -> Optional[Dict[str, Any]]:
         """

--- a/sources/AU/FederalRegister/test_bootstrap.py
+++ b/sources/AU/FederalRegister/test_bootstrap.py
@@ -1,0 +1,96 @@
+"""Regression tests for the Australian Federal Register adapter."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+import types
+import unittest
+from pathlib import Path
+
+
+MODULE_PATH = Path(__file__).with_name("bootstrap.py")
+if "common.pdf_extract" not in sys.modules:
+    pdf_extract = types.ModuleType("common.pdf_extract")
+    pdf_extract.extract_pdf_markdown = lambda *_args, **_kwargs: None
+    pdf_extract.preload_existing_ids = lambda *_args, **_kwargs: set()
+    sys.modules["common.pdf_extract"] = pdf_extract
+SPEC = importlib.util.spec_from_file_location("au_federal_register_bootstrap", MODULE_PATH)
+assert SPEC is not None and SPEC.loader is not None
+MODULE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(MODULE)
+
+
+class _RateLimiter:
+    def __init__(self) -> None:
+        self.calls = 0
+
+    def wait(self) -> None:
+        self.calls += 1
+
+
+class _Response:
+    def __init__(self, payload: object) -> None:
+        self.payload = payload
+        self.raise_calls = 0
+
+    def raise_for_status(self) -> None:
+        self.raise_calls += 1
+
+    def json(self) -> object:
+        return self.payload
+
+
+class _Client:
+    def __init__(self, response: _Response) -> None:
+        self.response = response
+        self.urls: list[str] = []
+
+    def get(self, url: str) -> _Response:
+        self.urls.append(url)
+        return self.response
+
+
+def _scraper(payload: object):
+    scraper = object.__new__(MODULE.AustraliaFederalRegisterScraper)
+    scraper.rate_limiter = _RateLimiter()
+    scraper.client = _Client(_Response(payload))
+    return scraper
+
+
+class AustraliaFederalRegisterCountTests(unittest.TestCase):
+    def test_uses_inline_odata_count(self) -> None:
+        scraper = _scraper({"@odata.count": 13732, "value": [{}]})
+
+        count = scraper._get_total_count("collection eq 'Act'")
+
+        self.assertEqual(count, 13732)
+        self.assertEqual(scraper.rate_limiter.calls, 1)
+        self.assertEqual(
+            scraper.client.urls,
+            [
+                "/v1/titles?$top=1&$skip=0&$count=true"
+                "&$filter=collection eq 'Act'"
+            ],
+        )
+        self.assertEqual(scraper.client.response.raise_calls, 1)
+
+    def test_rejects_the_observed_minimum_integer_sentinel(self) -> None:
+        scraper = _scraper({"@odata.count": -9223372036854775808, "value": []})
+
+        with self.assertRaisesRegex(ValueError, "valid @odata.count"):
+            scraper._get_total_count("collection eq 'Act'")
+
+    def test_rejects_missing_boolean_or_non_integer_counts(self) -> None:
+        for payload in (
+            {"value": []},
+            {"@odata.count": True, "value": []},
+            {"@odata.count": "13732", "value": []},
+        ):
+            with self.subTest(payload=payload):
+                with self.assertRaisesRegex(ValueError, "valid @odata.count"):
+                    _scraper(payload)._get_total_count()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Outcome

Use the Federal Register inline OData count and reject invalid totals before pagination.

## Why

The official API currently returns HTTP 200 with the signed 64-bit minimum sentinel for the filtered `/v1/titles/$count` form used by this adapter. The inline `?$count=true` response returns a valid `@odata.count` (13,732 Acts in the bounded 2026-09-07 observation).

The old catch-all also converted transport, decoding, and invalid-count failures to zero, which could make a partial run look like an empty collection. The new path propagates those failures and therefore fails closed.

## Verification

- Added regression coverage for the valid inline response.
- Added coverage for the observed minimum-integer sentinel.
- Added coverage for missing, boolean, and string counts.
- `python -m unittest -v sources/AU/FederalRegister/test_bootstrap.py`: 3 passed.
- Python compilation and repository content preflight passed.

Closes #257

Refs esherialabs/case-laws-ingestion#375