### PR TITLE
Fix canonical licence inventory synchronization

### DIFF
--- a/.github/workflows/refresh-dashboard.yml
+++ b/.github/workflows/refresh-dashboard.yml
@@ -6,28 +6,67 @@ on:
     paths:
       - 'sources/**'
       - 'manifest.yaml'
+      - 'generate_dashboard.py'
+      - 'scripts/sync_licenses_json.py'
+      - '.github/workflows/refresh-dashboard.yml'
   workflow_dispatch:
+  schedule:
+    - cron: '17 */2 * * *'
 
 permissions:
   contents: write
 
+concurrency:
+  group: public-dashboard-publication
+  cancel-in-progress: false
+
 jobs:
   refresh:
+    if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: main
 
-      - name: Install dependencies
-        run: pip install pyyaml
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
 
-      - name: Generate dashboard data
-        run: python3 generate_dashboard.py
-
-      - name: Commit and push if changed
+      - name: Install dashboard dependencies
+        if: github.event_name != 'schedule'
         run: |
+          set -euo pipefail
+          python -m pip install pyyaml
+
+      - name: Refresh and publish
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+        run: |
+          set -euo pipefail
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add docs/status.json
-          git diff --cached --quiet && echo "No changes" && exit 0
-          git commit -m "Dashboard refresh"
-          git push
+          for attempt in 1 2 3; do
+            # This disposable runner drops only its own failed publication
+            # commit. Reapply to latest main, preserving community changes.
+            git fetch origin main
+            git reset --hard origin/main
+            if [[ "$EVENT_NAME" == "schedule" ]]; then
+              python3 scripts/sync_licenses_json.py
+            else
+              python3 generate_dashboard.py
+            fi
+            git add docs/status.json docs/licenses.json
+            if git diff --cached --quiet; then
+              echo "No changes"
+              exit 0
+            fi
+            git commit -m "Dashboard and licence inventory refresh"
+            if git push origin HEAD:main; then
+              exit 0
+            fi
+            echo "Publication push failed (attempt $attempt/3); retrying from latest main." >&2
+          done
+          echo "Publication failed after 3 attempts." >&2
+          exit 1

--- a/.github/workflows/test-license-sync.yml
+++ b/.github/workflows/test-license-sync.yml
@@ -1,0 +1,46 @@
+name: Test Licence Sync
+
+on:
+  pull_request:
+    paths:
+      - 'scripts/sync_licenses_json.py'
+      - 'generate_dashboard.py'
+      - 'tests/test_license_sync.py'
+      - '.github/workflows/refresh-dashboard.yml'
+      - '.github/workflows/test-license-sync.yml'
+      - 'docs/license-inventory-format.md'
+  push:
+    branches: [main]
+    paths:
+      - 'scripts/sync_licenses_json.py'
+      - 'generate_dashboard.py'
+      - 'tests/test_license_sync.py'
+      - '.github/workflows/refresh-dashboard.yml'
+      - '.github/workflows/test-license-sync.yml'
+      - 'docs/license-inventory-format.md'
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+          sparse-checkout: |
+            .github
+            scripts
+            tests
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Test offline HTTP mirroring and workflow safety
+        run: |
+          set -euo pipefail
+          python -m pip install pyyaml pytest
+          python -m pytest tests/test_license_sync.py -q

--- a/docs/license-inventory-format.md
+++ b/docs/license-inventory-format.md
@@ -1,0 +1,67 @@
+# Licence inventory (schema v2)
+
+`docs/licenses.json` is a **byte-for-byte mirror** of the already-public
+[canonical Hunter inventory](https://zachlaik.github.io/LegalDataHunter/licenses.json).
+The private Hunter manifest is canonical; its generator publishes this feed.
+This repository does not import private generator code or a private registry and
+must not regenerate licence decisions from its independently synced manifest.
+
+## Contract
+
+- `schema_version`: integer `2`.
+- `generated_at`: ISO datetime with a timezone, set by the canonical generator.
+- `sources`: an array of objects with `id`, `country`, `name`, `license_id`,
+  `license_name` (strings), `license_url` (string or `null`) and `commercial_use`.
+  Source IDs must be nonempty and unique. Blank names and licence IDs are valid
+  unresolved audit metadata; the mirror preserves them.
+- `commercial_use` is **only `true`, `false`, or `null`** in both source and
+  registry entries. `null` means **UNKNOWN**, not permission to use commercially
+  and not a confirmed prohibition. Missing permission in the upstream manifest
+  must become `null` in the generated feed. A missing field in the feed itself
+  is a schema error; strings and integer substitutes are rejected.
+- `summary` contains nonnegative integer `total_complete`, `commercial_ok`,
+  `non_commercial`, `commercial_unknown`, `unverified`, and `unique_license_ids`.
+  The first equals the source count. The three permission buckets count
+  `true`/`false`/`null` and partition the sources. `unverified` counts only the
+  literal licence ID `unverified`, not blank IDs or all unknown permissions.
+- `by_license` maps each source licence ID (including a blank one, if present)
+  to an object with string `display_name`, string-or-`null` `url`, `commercial_use`, and
+  nonnegative integer `count`. Its IDs and counts must match source grouping;
+  `unique_license_ids` counts these groups. Registry metadata and permissions
+  may differ from explicit source values: the mirror must not overwrite either.
+
+## Synchronization and rollout
+
+**Deploy private-first:** publish and verify the canonical schema-v2 feed before
+rolling out this public sync. A legacy feed is intentionally rejected, even if
+it is valid JSON; public refresh will fail until upstream v2 is available.
+Do not hand-edit the mirror or manufacture a successful initial inventory.
+
+Run only the licence sync with:
+
+```sh
+python3 scripts/sync_licenses_json.py
+```
+
+The stdlib-only copier uses a 30-second network timeout and a 10 MiB payload cap.
+It validates the complete response before atomic replacement, preserving the
+received bytes and metadata. Identical bytes are a no-op. An older timestamp
+than an existing parseable, timezone-aware `generated_at` is rejected (including
+when the existing file is legacy). Invalid JSON, HTTP failures, schema/count
+errors and duplicate IDs leave the existing inventory unchanged.
+
+The refresh workflow runs licence-only sync every two hours. Manual runs and
+relevant main-branch pushes generate `status.json` and sync licences; sync errors
+propagate and prevent publication. Publication is serialized, stages only
+`docs/status.json` and `docs/licenses.json`, and makes at most three non-force
+push attempts, fetching latest main and regenerating after a race. It does not
+copy or overwrite community source files. Source-code/manifest synchronization
+remains an independent process, so inventory and public manifest counts can
+differ legitimately. Preserve this public sync integration during that process.
+
+PR and relevant push tests never publish and use ephemeral HTTP servers bound
+to `127.0.0.1`, not the live feed. To run locally:
+
+```sh
+uv run --with pyyaml --with pytest python -m pytest tests/test_license_sync.py -q
+```

--- a/generate_dashboard.py
+++ b/generate_dashboard.py
@@ -737,12 +737,10 @@ def generate():
 
     print(f"Dashboard data generated: {complete}/{total} sources complete ({output['summary']['percent_complete']}%)")
 
-    # Also regenerate licenses.json
-    try:
-        from scripts.generate_licenses_json import main as generate_licenses
-        generate_licenses()
-    except Exception as e:
-        print(f"Warning: could not generate licenses.json: {e}")
+    # Mirror the canonical, already-public inventory; never infer licences from
+    # the independently synchronized public manifest. A failed sync must fail CI.
+    from scripts.sync_licenses_json import sync_licenses
+    sync_licenses(output=DOCS_DIR / "licenses.json")
 
 
 if __name__ == "__main__":

--- a/scripts/sync_licenses_json.py
+++ b/scripts/sync_licenses_json.py
@@ -1,0 +1,182 @@
+#!/usr/bin/env python3
+"""Validate and mirror the already-public canonical licence inventory verbatim."""
+
+import argparse
+from collections import Counter
+from datetime import datetime
+from http.client import HTTPException
+import json
+import os
+from pathlib import Path
+import sys
+import tempfile
+from urllib.request import urlopen
+
+DEFAULT_URL = "https://zachlaik.github.io/LegalDataHunter/licenses.json"
+DEFAULT_OUTPUT = Path(__file__).resolve().parents[1] / "docs/licenses.json"
+MAX_PAYLOAD_BYTES = 10 * 1024 * 1024
+FETCH_TIMEOUT_SECONDS = 30
+
+
+def _require(condition, message):
+    if not condition:
+        raise ValueError(message)
+
+
+def _timestamp(value):
+    _require(isinstance(value, str), "generated_at must be an ISO timezone datetime")
+    try:
+        timestamp = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        raise ValueError("generated_at must be an ISO timezone datetime") from None
+    _require(timestamp.tzinfo is not None, "generated_at must include a timezone")
+    return timestamp
+
+
+def _unique_object(pairs):
+    result = {}
+    for key, value in pairs:
+        _require(key not in result, "Duplicate JSON object key")
+        result[key] = value
+    return result
+
+
+def _invalid_constant(_value):
+    raise ValueError("Non-standard JSON constant")
+
+
+def _strings(record, fields):
+    _require(isinstance(record, dict), "Inventory entries must be objects")
+    for field in fields:
+        _require(isinstance(record.get(field), str), f"{field} must be a string")
+
+
+def _permission(record):
+    _require("commercial_use" in record, "commercial_use is required (null means unknown)")
+    value = record["commercial_use"]
+    _require(value is None or type(value) is bool, "commercial_use must be boolean or null")
+
+
+def _url(record, field):
+    _require(field in record and (record[field] is None or isinstance(record[field], str)),
+             f"{field} must be a string or null")
+
+
+def validate_inventory(payload):
+    """Check schema v2 and its aggregates without inferring licence permissions."""
+    try:
+        data = json.loads(payload, object_pairs_hook=_unique_object, parse_constant=_invalid_constant)
+    except (UnicodeError, json.JSONDecodeError, RecursionError):
+        raise ValueError("Invalid licence inventory JSON") from None
+    _require(isinstance(data, dict), "Inventory must be an object")
+    _require(type(data.get("schema_version")) is int and data["schema_version"] == 2,
+             "Canonical licence inventory must use schema_version 2; publish the upstream v2 feed first")
+    generated_at = _timestamp(data.get("generated_at"))
+    sources = data.get("sources")
+    summary = data.get("summary")
+    by_license = data.get("by_license")
+    _require(isinstance(sources, list), "sources must be an array")
+    _require(isinstance(summary, dict), "summary must be an object")
+    _require(isinstance(by_license, dict), "by_license must be an object")
+
+    ids = set()
+    counts = Counter()
+    permissions = Counter()
+    for source in sources:
+        _strings(source, ("id", "country", "name", "license_id", "license_name"))
+        _url(source, "license_url")
+        _require(bool(source["id"]) and source["id"] not in ids, "Source IDs must be nonempty and unique")
+        ids.add(source["id"])
+        _permission(source)
+        counts[source["license_id"]] += 1
+        permissions[source["commercial_use"]] += 1
+
+    expected = {
+        "total_complete": len(sources),
+        "commercial_ok": permissions[True],
+        "non_commercial": permissions[False],
+        "commercial_unknown": permissions[None],
+        "unverified": counts["unverified"],
+        "unique_license_ids": len(counts),
+    }
+    for field, count in expected.items():
+        value = summary.get(field)
+        _require(type(value) is int and value >= 0 and value == count,
+                 f"summary.{field} must be a nonnegative integer matching sources")
+
+    _require(set(by_license) == set(counts), "by_license IDs must match source grouping")
+    for license_id, entry in by_license.items():
+        _strings(entry, ("display_name",))
+        _url(entry, "url")
+        _permission(entry)
+        count = entry.get("count")
+        _require(type(count) is int and count >= 0 and count == counts[license_id],
+                 "by_license count must be a nonnegative integer matching sources")
+    return generated_at
+
+
+def sync_licenses(url=DEFAULT_URL, output=DEFAULT_OUTPUT):
+    """Copy validated bytes atomically; return False for an identical inventory.
+
+    Failures propagate and leave the existing file unchanged. Only a parseable,
+    timezone-aware existing generated_at participates in the rollback check;
+    this also protects an existing legacy inventory during the v2 rollout.
+    """
+    with urlopen(url, timeout=FETCH_TIMEOUT_SECONDS) as response:
+        _require(response.status == 200, "Expected a complete HTTP 200 inventory response")
+        length = response.headers.get("Content-Length")
+        if length is not None:
+            _require(length.isdigit(), "Invalid HTTP Content-Length")
+            length = int(length)
+            _require(length <= MAX_PAYLOAD_BYTES, "Inventory exceeds the 10 MiB limit")
+        payload = response.read(MAX_PAYLOAD_BYTES + 1)
+        _require(len(payload) <= MAX_PAYLOAD_BYTES, "Inventory exceeds the 10 MiB limit")
+        _require(length is None or len(payload) == length, "Truncated inventory HTTP response")
+    generated_at = validate_inventory(payload)
+    output = Path(output)
+    previous = output.read_bytes() if output.exists() else None
+    if previous is not None:
+        try:
+            old_data = json.loads(previous)
+            old_timestamp = _timestamp(old_data.get("generated_at")) if isinstance(old_data, dict) else None
+        except (ValueError, UnicodeError, RecursionError):
+            old_timestamp = None
+        _require(old_timestamp is None or generated_at >= old_timestamp,
+                 "Refusing inventory timestamp rollback: received an older generated_at")
+        if payload == previous:
+            return False
+
+    output.parent.mkdir(parents=True, exist_ok=True)
+    temporary = None
+    try:
+        with tempfile.NamedTemporaryFile(dir=output.parent, prefix=f".{output.name}.", delete=False) as stream:
+            temporary = Path(stream.name)
+            stream.write(payload)
+            stream.flush()
+            os.fsync(stream.fileno())
+        os.replace(temporary, output)
+    finally:
+        if temporary is not None:
+            temporary.unlink(missing_ok=True)
+    return True
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--url", default=DEFAULT_URL, help="Canonical inventory URL")
+    parser.add_argument("--output", type=Path, default=DEFAULT_OUTPUT, help="Destination JSON file")
+    args = parser.parse_args()
+    try:
+        changed = sync_licenses(url=args.url, output=args.output)
+    except (ValueError, OSError, HTTPException) as error:
+        # Exception text from remote services can contain untrusted content.
+        # The helper propagates errors; the CLI deliberately logs no payload.
+        print(f"Licence sync failed ({type(error).__name__}); existing inventory preserved. "
+              "Check upstream availability and schema v2.", file=sys.stderr)
+        return 1
+    print("Licence inventory synced." if changed else "Licence inventory unchanged.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_license_sync.py
+++ b/tests/test_license_sync.py
@@ -1,0 +1,475 @@
+"""Offline regressions for the public licence mirror (never use the live feed)."""
+
+import importlib
+import json
+import os
+from pathlib import Path
+import subprocess
+import sys
+import threading
+import types
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from unittest.mock import Mock
+
+import pytest
+import yaml
+
+ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_URL = "https://zachlaik.github.io/LegalDataHunter/licenses.json"
+MAX_BYTES = 10 * 1024 * 1024
+
+
+def inventory():
+    # Deliberately inconsistent registry/source metadata is valid: the registry
+    # is not authority to overwrite an explicit source value. Blank IDs/names
+    # represent unresolved audit metadata, not the literal 'unverified' ID.
+    sources = [
+        {"id": "XX/Allowed", "country": "XX", "name": "Allowed", "license_id": "open",
+         "license_name": "Source-specific name", "license_url": "https://example.org/source", "commercial_use": True},
+        {"id": "XX/Denied", "country": "XX", "name": "Denied", "license_id": "open",
+         "license_name": "", "license_url": "", "commercial_use": False},
+        {"id": "XX/Unknown", "country": "XX", "name": "", "license_id": "",
+         "license_name": "", "license_url": "", "commercial_use": None},
+        {"id": "XX/Unverified", "country": "XX", "name": "Unverified", "license_id": "unverified",
+         "license_name": "Unverified", "license_url": "", "commercial_use": None},
+    ]
+    return {
+        "schema_version": 2,
+        "generated_at": "2026-09-08T10:00:00+00:00",
+        "summary": {"total_complete": 4, "commercial_ok": 1, "non_commercial": 1,
+                    "commercial_unknown": 2, "unverified": 1, "unique_license_ids": 3},
+        "by_license": {
+            "open": {"display_name": "Registry name", "url": "https://example.org/registry", "commercial_use": None, "count": 2},
+            "": {"display_name": "", "url": "", "commercial_use": None, "count": 1},
+            "unverified": {"display_name": "Unverified", "url": "", "commercial_use": None, "count": 1},
+        },
+        "sources": sources,
+    }
+
+
+def encode(data):
+    return (json.dumps(data, ensure_ascii=False, indent=3) + "\n\n").encode("utf-8")
+
+
+@pytest.fixture
+def http_feed():
+    """A real bounded local HTTP server, shut down and joined after each test."""
+    state = {"body": encode(inventory()), "status": 200, "length": "auto", "requests": []}
+
+    class Handler(BaseHTTPRequestHandler):
+        def do_GET(self):
+            state["requests"].append(self.path)
+            self.send_response(state["status"])
+            self.send_header("Content-Type", "application/json")
+            length = state["length"]
+            if length is not None:
+                self.send_header("Content-Length", str(len(state["body"]) if length == "auto" else length))
+            self.end_headers()
+            try:
+                self.wfile.write(state["body"])
+            except (BrokenPipeError, ConnectionResetError):
+                pass  # Expected when an over-limit response is rejected early.
+
+        def log_message(self, *_args):
+            pass
+
+    server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+    thread = threading.Thread(target=lambda: server.serve_forever(poll_interval=0.01))
+    thread.start()
+    state["url"] = f"http://127.0.0.1:{server.server_port}/licenses.json"
+    try:
+        yield state
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=2)
+        assert not thread.is_alive()
+
+
+@pytest.fixture
+def sync_module():
+    assert (ROOT / "scripts/sync_licenses_json.py").is_file(), "The public mirror needs a licence sync implementation"
+    return importlib.import_module("scripts.sync_licenses_json")
+
+
+@pytest.fixture
+def dashboard(monkeypatch, tmp_path):
+    module = importlib.import_module("generate_dashboard")
+    monkeypatch.setattr(module, "DOCS_DIR", tmp_path / "docs")
+    for name, value in {
+        "load_manifest": {"sources": []}, "_load_neon_database_url": None,
+        "load_pipeline_index": {}, "load_contributors": {},
+        "parse_blocked_md": [], "get_session_logs": ([], ""),
+    }.items():
+        monkeypatch.setattr(module, name, Mock(return_value=value))
+    return module
+
+
+def stub_license_modules(monkeypatch, sync):
+    # Stubbing both old/new integration targets lets RED exercise generate()
+    # itself, not fail during collection due to an absent scripts package.
+    package = types.ModuleType("scripts")
+    package.__path__ = []
+    old_module = types.ModuleType("scripts.generate_licenses_json")
+    old_module.main = Mock(side_effect=RuntimeError("private generator is unavailable in the public repo"))
+    new_module = types.ModuleType("scripts.sync_licenses_json")
+    new_module.sync_licenses = sync
+    monkeypatch.setitem(sys.modules, "scripts", package)
+    monkeypatch.setitem(sys.modules, old_module.__name__, old_module)
+    monkeypatch.setitem(sys.modules, new_module.__name__, new_module)
+    return old_module.main
+
+
+def test_dashboard_copies_canonical_inventory_instead_of_regenerating(dashboard, monkeypatch):
+    sync = Mock()
+    old_generator = stub_license_modules(monkeypatch, sync)
+    dashboard.generate()
+    sync.assert_called_once_with(output=dashboard.DOCS_DIR / "licenses.json")
+    old_generator.assert_not_called()
+
+
+def test_dashboard_propagates_sync_failure(dashboard, monkeypatch):
+    sync = Mock(side_effect=RuntimeError("canonical feed unavailable"))
+    stub_license_modules(monkeypatch, sync)
+    with pytest.raises(RuntimeError, match="canonical feed unavailable"):
+        dashboard.generate()
+
+
+def test_copies_exact_bytes_and_preserves_unknown_and_source_metadata(sync_module, http_feed, tmp_path):
+    data = inventory()
+    data["sources"][0]["name"] = "Législation ⚖"
+    data["audit_note"] = "Additional public metadata is preserved, not regenerated."
+    http_feed["body"] = encode(data)
+    output = tmp_path / "docs/licenses.json"
+    assert sync_module.sync_licenses(url=http_feed["url"], output=output) is True
+    assert output.read_bytes() == http_feed["body"]
+    assert http_feed["requests"] == ["/licenses.json"]
+
+
+def test_identical_bytes_are_a_noop(sync_module, http_feed, tmp_path):
+    output = tmp_path / "licenses.json"
+    output.write_bytes(http_feed["body"])
+    before = output.stat()
+    assert sync_module.sync_licenses(url=http_feed["url"], output=output) is False
+    after = output.stat()
+    assert (after.st_ino, after.st_mtime_ns) == (before.st_ino, before.st_mtime_ns)
+
+
+def set_field(data, path, value):
+    target = data
+    for key in path[:-1]:
+        target = target[key]
+    target[path[-1]] = value
+
+
+INVALID_FIELDS = [
+    (("schema_version",), 1), (("schema_version",), 2.0), (("schema_version",), True),
+    (("generated_at",), "2026-09-08"), (("generated_at",), "2026-09-08T10:00:00"),
+    (("generated_at",), "yesterday"), (("generated_at",), None),
+    (("sources",), {}), (("sources", 0), []), (("sources", 0, "id"), ""),
+    (("sources", 0, "id"), 42), (("sources", 0, "country"), None),
+    (("sources", 0, "name"), None), (("sources", 0, "license_id"), None),
+    (("sources", 0, "license_name"), []), (("sources", 0, "license_url"), False),
+    (("sources", 1, "id"), "XX/Allowed"),
+    (("by_license",), []), (("by_license", "open"), None),
+    (("by_license", "open", "display_name"), None), (("by_license", "open", "url"), 5),
+    (("by_license", "open", "count"), 1), (("by_license", "open", "count"), True),
+    (("by_license", "open", "count"), -1), (("by_license", "open", "count"), 2.0),
+    (("summary",), []),
+] + [
+    (("summary", key), value)
+    for key in inventory()["summary"] for value in [-1, True, "1", 1.0, 99]
+] + [
+    (("sources", 0, "commercial_use"), value) for value in [0, 1, "true", "false", "unknown", [], {}]
+] + [
+    (("by_license", "open", "commercial_use"), value) for value in [0, 1, "true", "false", "unknown", [], {}]
+]
+
+
+@pytest.mark.parametrize("path,value", INVALID_FIELDS)
+def test_invalid_field_never_alters_existing_output(sync_module, http_feed, tmp_path, path, value):
+    data = inventory()
+    set_field(data, path, value)
+    http_feed["body"] = encode(data)
+    output = tmp_path / "licenses.json"
+    output.write_bytes(b"existing inventory must survive")
+    with pytest.raises(ValueError):
+        sync_module.sync_licenses(url=http_feed["url"], output=output)
+    assert output.read_bytes() == b"existing inventory must survive"
+    assert list(tmp_path.iterdir()) == [output]
+
+
+@pytest.mark.parametrize("path", [("sources", 0, "license_url"), ("by_license", "open", "url")])
+def test_nullable_urls_are_preserved_as_canonical_metadata(sync_module, http_feed, tmp_path, path):
+    data = inventory()
+    set_field(data, path, None)
+    http_feed["body"] = encode(data)
+    output = tmp_path / "licenses.json"
+    assert sync_module.sync_licenses(url=http_feed["url"], output=output) is True
+    assert output.read_bytes() == http_feed["body"]
+
+
+@pytest.mark.parametrize("path", [
+    ("schema_version",), ("generated_at",), ("summary",), ("sources",), ("by_license",),
+    ("summary", "commercial_unknown"), ("sources", 0, "commercial_use"),
+    ("sources", 0, "license_url"), ("by_license", "open", "url"),
+    ("sources", 0, "license_name"), ("by_license", "open", "commercial_use"),
+    ("by_license", "open", "count"), ("by_license", "open"),
+])
+def test_missing_required_fields_fail_closed(sync_module, http_feed, tmp_path, path):
+    data = inventory()
+    target = data
+    for key in path[:-1]:
+        target = target[key]
+    del target[path[-1]]
+    http_feed["body"] = encode(data)
+    output = tmp_path / "licenses.json"
+    output.write_bytes(b"previous")
+    with pytest.raises(ValueError):
+        sync_module.sync_licenses(url=http_feed["url"], output=output)
+    assert output.read_bytes() == b"previous"
+
+
+def test_extra_registry_id_is_rejected_even_with_zero_count(sync_module, http_feed, tmp_path):
+    data = inventory()
+    data["by_license"]["extra"] = dict(data["by_license"]["open"], count=0)
+    data["summary"]["unique_license_ids"] = 4
+    http_feed["body"] = encode(data)
+    output = tmp_path / "licenses.json"
+    output.write_bytes(b"previous")
+    with pytest.raises(ValueError):
+        sync_module.sync_licenses(url=http_feed["url"], output=output)
+    assert output.read_bytes() == b"previous"
+
+
+@pytest.mark.parametrize("body", [b"{", b"not json", b"[]", b"null", b"\xff", b"{}",
+    b'{"schema_version": 2, "schema_version": 2}',
+    encode(inventory()).replace(b'"schema_version": 2,', b'"schema_version": 2, "extra": NaN,'),
+])
+def test_bad_or_legacy_json_is_not_written(sync_module, http_feed, tmp_path, body):
+    http_feed["body"] = body
+    output = tmp_path / "licenses.json"
+    output.write_bytes(b"previous")
+    with pytest.raises(ValueError):
+        sync_module.sync_licenses(url=http_feed["url"], output=output)
+    assert output.read_bytes() == b"previous"
+
+
+@pytest.mark.parametrize("status", [404, 500])
+def test_http_errors_preserve_existing_file(sync_module, http_feed, tmp_path, status):
+    from urllib.error import HTTPError
+    http_feed["status"] = status
+    output = tmp_path / "licenses.json"
+    output.write_bytes(b"previous")
+    with pytest.raises(HTTPError):
+        sync_module.sync_licenses(url=http_feed["url"], output=output)
+    assert output.read_bytes() == b"previous"
+
+
+@pytest.mark.parametrize("length", ["auto", None])
+def test_oversized_response_is_rejected_with_or_without_length(sync_module, http_feed, tmp_path, length):
+    http_feed.update(body=b" " * (MAX_BYTES + 1), length=length)
+    output = tmp_path / "licenses.json"
+    output.write_bytes(b"previous")
+    with pytest.raises(ValueError):
+        sync_module.sync_licenses(url=http_feed["url"], output=output)
+    assert output.read_bytes() == b"previous"
+
+
+def test_valid_json_in_truncated_http_body_is_rejected(sync_module, http_feed, tmp_path):
+    http_feed["length"] = len(http_feed["body"]) + 100
+    output = tmp_path / "licenses.json"
+    output.write_bytes(b"previous")
+    with pytest.raises((ValueError, OSError)):
+        sync_module.sync_licenses(url=http_feed["url"], output=output)
+    assert output.read_bytes() == b"previous"
+
+
+@pytest.mark.parametrize("existing_timestamp,incoming_timestamp,allowed", [
+    ("2026-09-08T10:00:01+00:00", "2026-09-08T10:00:00Z", False),
+    ("2026-09-08T12:00:00+02:00", "2026-09-08T10:00:00Z", True),
+    ("2026-09-08T12:00:00+02:00", "2026-09-08T10:00:01Z", True),
+    ("bad", "2026-09-08T10:00:00Z", True),
+])
+def test_timestamp_rollback_uses_existing_timestamp_even_if_legacy(sync_module, http_feed, tmp_path,
+        existing_timestamp, incoming_timestamp, allowed):
+    output = tmp_path / "licenses.json"
+    before = encode({"generated_at": existing_timestamp})
+    output.write_bytes(before)
+    data = inventory()
+    data["generated_at"] = incoming_timestamp
+    http_feed["body"] = encode(data)
+    if allowed:
+        assert sync_module.sync_licenses(url=http_feed["url"], output=output) is True
+        assert output.read_bytes() == http_feed["body"]
+    else:
+        with pytest.raises(ValueError, match="(?i)older|rollback"):
+            sync_module.sync_licenses(url=http_feed["url"], output=output)
+        assert output.read_bytes() == before
+
+
+def test_atomic_replace_failure_preserves_previous_and_cleans_temp(sync_module, http_feed, tmp_path, monkeypatch):
+    output = tmp_path / "licenses.json"
+    output.write_bytes(b"previous")
+
+    def fail_replace(source, destination):
+        assert Path(source).parent == output.parent
+        assert Path(source).read_bytes() == http_feed["body"]
+        assert Path(destination) == output
+        assert output.read_bytes() == b"previous"
+        raise OSError("replacement unavailable")
+
+    monkeypatch.setattr(sync_module.os, "replace", fail_replace)
+    with pytest.raises(OSError, match="replacement unavailable"):
+        sync_module.sync_licenses(url=http_feed["url"], output=output)
+    assert output.read_bytes() == b"previous"
+    assert list(tmp_path.iterdir()) == [output]
+
+
+def test_default_url_and_network_read_are_bounded(sync_module, http_feed, tmp_path, monkeypatch):
+    from urllib.request import urlopen
+    calls = []
+
+    def local_urlopen(url, *, timeout):
+        calls.append((url, timeout))
+        return urlopen(http_feed["url"], timeout=timeout)
+
+    monkeypatch.setattr(sync_module, "urlopen", local_urlopen)
+    sync_module.sync_licenses(output=tmp_path / "licenses.json")
+    assert calls[0][0] == DEFAULT_URL
+    assert 0 < calls[0][1] <= 30
+
+
+def test_empty_inventory_is_valid(sync_module, http_feed, tmp_path):
+    data = inventory()
+    data.update(sources=[], by_license={})
+    data["summary"] = {key: 0 for key in data["summary"]}
+    http_feed["body"] = encode(data)
+    output = tmp_path / "licenses.json"
+    assert sync_module.sync_licenses(url=http_feed["url"], output=output) is True
+    assert output.read_bytes() == http_feed["body"]
+
+
+def test_cli_local_http_success_noop_and_failure(sync_module, http_feed, tmp_path):
+    output = tmp_path / "licenses.json"
+    command = [sys.executable, str(ROOT / "scripts/sync_licenses_json.py"),
+               "--url", http_feed["url"], "--output", str(output)]
+    first = subprocess.run(command, text=True, capture_output=True, timeout=10)
+    assert first.returncode == 0, first.stderr
+    assert output.read_bytes() == http_feed["body"]
+    before = output.stat().st_mtime_ns
+    second = subprocess.run(command, text=True, capture_output=True, timeout=10)
+    assert second.returncode == 0, second.stderr
+    assert output.stat().st_mtime_ns == before
+    http_feed["body"] = b"DO_NOT_LOG_DOWNLOADED_PAYLOAD"
+    failed = subprocess.run(command, text=True, capture_output=True, timeout=10)
+    assert failed.returncode != 0
+    assert "DO_NOT_LOG_DOWNLOADED_PAYLOAD" not in failed.stdout + failed.stderr
+    assert output.stat().st_mtime_ns == before
+
+
+def load_workflow(name):
+    path = ROOT / ".github/workflows" / name
+    assert path.is_file(), f"Missing focused workflow: {name}"
+    return yaml.load(path.read_text(), Loader=yaml.BaseLoader)
+
+
+def test_refresh_workflow_has_safe_triggers_and_serializes_publication():
+    workflow = load_workflow("refresh-dashboard.yml")
+    triggers = workflow["on"]
+    assert set(triggers) == {"push", "workflow_dispatch", "schedule"}
+    assert triggers["push"]["branches"] == ["main"]
+    assert {"sources/**", "manifest.yaml", "generate_dashboard.py", "scripts/sync_licenses_json.py",
+            ".github/workflows/refresh-dashboard.yml"} <= set(triggers["push"]["paths"])
+    cron = triggers["schedule"][0]["cron"].split()
+    assert cron[1:] == ["*/2", "*", "*", "*"]
+    assert workflow["concurrency"]["group"]
+    assert workflow["concurrency"]["cancel-in-progress"] == "false"
+    refresh = workflow["jobs"]["refresh"]
+    assert "github.ref == 'refs/heads/main'" in refresh["if"]
+    checkout = next(step for step in refresh["steps"] if step.get("uses", "").startswith("actions/checkout@"))
+    assert checkout["with"]["ref"] == "main"
+    scripts = "\n".join(step.get("run", "") for step in refresh["steps"])
+    assert "git add docs/status.json docs/licenses.json" in scripts
+    assert "set -euo pipefail" in scripts
+    assert "--force" not in scripts
+    assert "git add -A" not in scripts
+    assert "git pull" not in scripts
+
+
+def test_test_workflow_runs_on_pr_and_relevant_push_without_publication():
+    workflow = load_workflow("test-license-sync.yml")
+    assert set(workflow["on"]) == {"pull_request", "push"}
+    for event in ["pull_request", "push"]:
+        assert {"scripts/sync_licenses_json.py", "generate_dashboard.py", "tests/test_license_sync.py",
+                ".github/workflows/refresh-dashboard.yml", ".github/workflows/test-license-sync.yml"} <= set(workflow["on"][event]["paths"])
+    assert workflow["permissions"] == {"contents": "read"}
+    scripts = "\n".join(step.get("run", "") for job in workflow["jobs"].values() for step in job["steps"])
+    assert "python -m pytest tests/test_license_sync.py" in scripts
+    assert "git push" not in scripts
+    assert "git commit" not in scripts
+    assert "python3 generate_dashboard.py" not in scripts
+
+
+@pytest.mark.parametrize("event,push_failures,generation_failure,no_changes,expected_attempts,exit_code", [
+    ("schedule", 0, False, False, 1, 0),
+    ("push", 1, False, False, 2, 0),
+    ("workflow_dispatch", 3, False, False, 3, 1),
+    ("schedule", 0, True, False, 1, 1),
+    ("push", 0, False, True, 1, 0),
+])
+def test_publication_shell_modes_retries_and_fail_closed(tmp_path, event, push_failures,
+        generation_failure, no_changes, expected_attempts, exit_code):
+    # Execute the workflow's actual bash, but use local test doubles for git and
+    # generation. No git commits, pushes, credentials or external calls occur.
+    workflow = load_workflow("refresh-dashboard.yml")
+    steps = workflow["jobs"]["refresh"]["steps"]
+    publication = [step for step in steps if "git push" in step.get("run", "")]
+    assert len(publication) == 1
+    step = publication[0]
+    assert step.get("env", {}).get("EVENT_NAME") == "${{ github.event_name }}"
+    script = step["run"]
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    log = tmp_path / "calls.jsonl"
+    stub = '''import json, os, pathlib, sys
+name = pathlib.Path(sys.argv[0]).name
+args = sys.argv[1:]
+log = pathlib.Path(os.environ["CALL_LOG"])
+previous = [json.loads(line) for line in log.read_text().splitlines()] if log.exists() else []
+with log.open("a") as stream:
+    stream.write(json.dumps([name, *args]) + "\\n")
+if name == "python3":
+    sys.exit(1 if os.environ["GENERATION_FAILURE"] == "1" else 0)
+if args[:1] == ["push"]:
+    count = sum(call[:2] == ["git", "push"] for call in previous)
+    sys.exit(1 if count < int(os.environ["PUSH_FAILURES"]) else 0)
+if args[:3] == ["diff", "--cached", "--quiet"]:
+    sys.exit(0 if os.environ["NO_CHANGES"] == "1" else 1)
+'''
+    for name in ["git", "python3"]:
+        executable = bin_dir / name
+        executable.write_text(f"#!{sys.executable}\n" + stub)
+        executable.chmod(0o755)
+    env = dict(os.environ, PATH=f"{bin_dir}:{os.environ['PATH']}", EVENT_NAME=event,
+               CALL_LOG=str(log), PUSH_FAILURES=str(push_failures),
+               GENERATION_FAILURE=str(int(generation_failure)), NO_CHANGES=str(int(no_changes)))
+    result = subprocess.run(["bash", "-c", script], cwd=tmp_path, env=env,
+                            text=True, capture_output=True, timeout=20)
+    assert result.returncode == exit_code, result.stdout + result.stderr
+    calls = [json.loads(line) for line in log.read_text().splitlines()]
+    generations = [call for call in calls if call[0] == "python3"]
+    command = "scripts/sync_licenses_json.py" if event == "schedule" else "generate_dashboard.py"
+    assert generations == [["python3", command]] * expected_attempts
+    fetches = [i for i, call in enumerate(calls) if call == ["git", "fetch", "origin", "main"]]
+    resets = [i for i, call in enumerate(calls) if call == ["git", "reset", "--hard", "origin/main"]]
+    assert len(fetches) == len(resets) == expected_attempts
+    generated = [i for i, call in enumerate(calls) if call[0] == "python3"]
+    assert all(fetch < reset < generate for fetch, reset, generate in zip(fetches, resets, generated))
+    if generation_failure:
+        assert not any(call[:2] in [["git", "add"], ["git", "commit"], ["git", "push"]] for call in calls)
+    else:
+        stages = [call for call in calls if call[:2] == ["git", "add"]]
+        assert stages == [["git", "add", "docs/status.json", "docs/licenses.json"]] * expected_attempts
+        pushes = [call for call in calls if call[:2] == ["git", "push"]]
+        assert pushes == ([] if no_changes else [["git", "push", "origin", "HEAD:main"]] * expected_attempts)


### PR DESCRIPTION
## Summary
- Replace the public dashboard's missing private licence generator with a stdlib copier of the already-public canonical Pages inventory.
- Require schema v2, where commercial permission is explicitly true, false, or null (Unknown). Validate grouping, counts, IDs, timestamps, and types without inventing source permissions.
- Keep exact response bytes, bound HTTP reads, reject invalid/legacy/older payloads, atomically replace valid output, and no-op on identical input.
- Repair the existing Refresh Dashboard workflow: two-hour licence-only synchronization, preserved source/manifest pushes and manual refresh, explicit staging of both JSON outputs, serialized non-force publication with bounded retry.
- Add read-only PR tests and document the contract and rollout order.

## Verification
- RED: existing dashboard/workflow behavior failed 9 integration/publication-shell cases before implementation. Two further nullable-URL regression cases failed before compatibility correction against real generated data.
- GREEN: `uv run --with pyyaml --with pytest python -m pytest tests/test_license_sync.py -q`: 118 passed. Parent independently reran this and an artifact-free source-only copy: both 118 passed.
- `actionlint` for both workflows and `git diff --check`: passed.
- Actual current-manifest private output -> temporary loopback HTTP -> actual public copier: 2,189 entries, exact byte match, 22 unknowns preserved; repeated copy was a no-op.
- Real canonical endpoint remains legacy at verification time: the copier rejected it and preserved the existing local inventory. This is expected rollout gating, not a successful live refresh claim.
- Changed-path secret scan: no findings. Only 6 intended paths; no broad source, manifest, private-input, credential, or generated-data copy.

## Rollout dependency / limitations
Depends on the private generator fix in ZachLaik/LegalDataHunter#1605. Merge/publish that change first, let private refresh and Pages publish schema v2, and verify the canonical endpoint before merging this public change. The public main-branch merge itself triggers its existing refresh workflow; later scheduled runs perform licence-only sync.

The public source-code/manifest mirror remains independently maintained and can lag the canonical licence inventory. Preserve the public copier integration during future broad source syncs. Existing source-specific licensing audits are unchanged; this PR is metadata transport/format repair, not a legal determination.

No live refresh, workflow dispatch, merge, or production publication has been performed. Independent specification review passed. Separate technical quality review passed with no security concerns or logic errors; its only non-blocking suggestion was additional temporary-write/fsync fault-injection coverage beyond the existing atomic-replace failure test. All six reviewed file hashes were checked before the exact-path commit.

Head: `50a03112959b70de36327466d22abacbd2883617`. The commit attribution was corrected with Zach's explicit approval; its reviewed code tree is byte-identical to the original reviewed commit, and GitHub now links both author and committer to `ZachLaik`. No agreement was signed or CLA gate bypassed.

Remote `Test Licence Sync` CI passed on this exact head. The remaining `CLA Assistant` failure explicitly requires the contributor's CLA signature; the author-linkage warning is resolved. Keep as a draft pending the human CLA step and private-first rollout approval.
