### PR TITLE
fix: restore tri-state license inventory and public refresh dependencies

### DIFF
--- a/.github/workflows/license-inventory-tests.yml
+++ b/.github/workflows/license-inventory-tests.yml
@@ -1,0 +1,28 @@
+name: License inventory tests
+
+on:
+  pull_request:
+    paths:
+      - 'scripts/generate_licenses_json.py'
+      - 'scripts/validate_licenses.py'
+      - 'generate_dashboard.py'
+      - 'license_registry.yaml'
+      - 'tests/test_license_*.py'
+      - '.github/workflows/refresh-dashboard.yml'
+      - '.github/workflows/license-inventory-tests.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  fixtures:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install fixture dependencies
+        run: python -m pip install pytest pyyaml
+      - name: Run offline contract and refresh tests
+        run: python -m pytest tests/test_license_inventory.py tests/test_license_refresh.py -q

--- a/.github/workflows/refresh-dashboard.yml
+++ b/.github/workflows/refresh-dashboard.yml
@@ -6,6 +6,13 @@ on:
     paths:
       - 'sources/**'
       - 'manifest.yaml'
+      - 'license_registry.yaml'
+      - 'generate_dashboard.py'
+      - 'scripts/generate_licenses_json.py'
+      - '.github/workflows/refresh-dashboard.yml'
+  schedule:
+    # Also refresh after bot-token sync pushes (which do not trigger workflows).
+    - cron: '17 */2 * * *'
   workflow_dispatch:
 
 permissions:
@@ -27,7 +34,7 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add docs/status.json
+          git add docs/status.json docs/licenses.json
           git diff --cached --quiet && echo "No changes" && exit 0
           git commit -m "Dashboard refresh"
           git push

--- a/LICENSE_INVENTORY.md
+++ b/LICENSE_INVENTORY.md
@@ -1,0 +1,61 @@
+# License inventory contract and refresh
+
+`commercial_use` is tri-state: `true` = explicitly permitted, `false` = explicitly
+restricted, `null` (including an absent manifest field) = unknown. Only literal
+booleans or null are accepted; strings, numbers, lists, and mappings fail generation.
+Existing booleans and source IDs are preserved. The generator does not fill in
+license metadata, infer source permissions from taxonomy, or deduplicate sources.
+Only `status: complete` sources appear in the inventory.
+
+`summary.commercial_ok`, `summary.non_commercial`, and the new
+`summary.commercial_unknown` are disjoint and sum to `summary.total_complete`.
+`summary.unverified` remains the count of `license_id: unverified`, an independent
+axis that can overlap any commercial-use state. Consumers must use explicit
+boolean comparisons, not truthiness or `total_complete - non_commercial`.
+This inventory is not a blanket commercial-use whitelist or a legal clearance.
+
+The validator accepts absent/null commercial use with a research warning and
+rejects non-boolean values. Existing license ID/name requirements and explicit
+registry-consistency checks remain. `--strict` still fails on unverified license
+IDs; it does not make unknown commercial permission into a false determination.
+
+Run from the repository root, with Python and PyYAML installed:
+
+```sh
+python scripts/validate_licenses.py
+python generate_dashboard.py
+```
+
+License generation is a required first step in dashboard generation. Missing
+scripts, missing taxonomy, parse failures, and invalid commercial-use types exit
+nonzero before status output is rewritten. Workflow publication runs only after
+successful generation and must stage both `docs/status.json` and `docs/licenses.json`.
+The two writes are not a filesystem transaction; a later dashboard failure still
+stops workflow publication.
+
+Offline regression tests (pytest + PyYAML):
+
+```sh
+python -m pytest tests/test_license_inventory.py tests/test_license_refresh.py -q
+```
+
+Tests use synthetic manifests and temporary checkouts, not production data or a
+database. PR CI runs only these fixtures, not a refresh or publication.
+
+## Public mirror prerequisites
+
+The public repository must carry these self-contained, non-secret files:
+`generate_dashboard.py`, `scripts/generate_licenses_json.py`,
+`license_registry.yaml`, and its refresh workflow. The registry contains generic
+license taxonomy only, not source determinations. Keep the generator, taxonomy,
+and fixture tests aligned across repositories. Public refresh uses its own
+checked-in manifest; it does not read private sources, a private database, or
+private modules. Schedule refresh as well as input-file push triggers, because
+GitHub-token bot pushes do not trigger new push workflows.
+
+No private-to-public export/sync implementation was found in the checked-in
+scripts or workflows during this fix. Any external exporter must preserve this
+allowlist and synchronize reviewed manifest changes through its existing approval
+process; that external integration is not changed or verified here. Do not copy
+private manifests, source metadata, credentials, or generated snapshots to fix
+missing public code dependencies.

--- a/generate_dashboard.py
+++ b/generate_dashboard.py
@@ -513,6 +513,11 @@ def get_session_logs(limit=10):
 
 
 def generate():
+    # License generation is required. Fail before writing status on bad inputs
+    # or missing dependencies so automation cannot publish a stale inventory.
+    from scripts.generate_licenses_json import main as generate_licenses
+    generate_licenses()
+
     manifest = load_manifest()
     sources = manifest.get("sources", [])
     neon_live = bool(_load_neon_database_url())
@@ -736,13 +741,6 @@ def generate():
         json.dump(output, f, indent=2, ensure_ascii=False)
 
     print(f"Dashboard data generated: {complete}/{total} sources complete ({output['summary']['percent_complete']}%)")
-
-    # Also regenerate licenses.json
-    try:
-        from scripts.generate_licenses_json import main as generate_licenses
-        generate_licenses()
-    except Exception as e:
-        print(f"Warning: could not generate licenses.json: {e}")
 
 
 if __name__ == "__main__":

--- a/license_registry.yaml
+++ b/license_registry.yaml
@@ -1,0 +1,133 @@
+# License Registry — canonical taxonomy for Legal Data Hunter
+# Each license_id maps to its display name, canonical URL, and commercial use status.
+# This is the single source of truth for the license taxonomy.
+
+licenses:
+  # ── Standard Open Licenses ────────────────────────────────────────
+  cc0-1.0:
+    display_name: "CC0 1.0"
+    url: "https://creativecommons.org/publicdomain/zero/1.0/"
+    commercial_use: true
+
+  cc-by-3.0:
+    display_name: "CC BY 3.0"
+    url: "https://creativecommons.org/licenses/by/3.0/"
+    commercial_use: true
+
+  cc-by-4.0:
+    display_name: "CC BY 4.0"
+    url: "https://creativecommons.org/licenses/by/4.0/"
+    commercial_use: true
+
+  cc-by-sa-3.0:
+    display_name: "CC BY-SA 3.0"
+    url: "https://creativecommons.org/licenses/by-sa/3.0/"
+    commercial_use: true
+
+  cc-by-sa-4.0:
+    display_name: "CC BY-SA 4.0"
+    url: "https://creativecommons.org/licenses/by-sa/4.0/"
+    commercial_use: true
+
+  cc-by-nc:
+    display_name: "CC BY-NC 4.0"
+    url: "https://creativecommons.org/licenses/by-nc/4.0/"
+    commercial_use: false
+
+  cc-by-nc-sa:
+    display_name: "CC BY-NC-SA 4.0"
+    url: "https://creativecommons.org/licenses/by-nc-sa/4.0/"
+    commercial_use: false
+
+  cc-by-nc-nd:
+    display_name: "CC BY-NC-ND 3.0"
+    url: "https://creativecommons.org/licenses/by-nc-nd/3.0/"
+    commercial_use: false
+
+  cc-by-nd-4.0:
+    display_name: "CC BY-ND 4.0"
+    url: "https://creativecommons.org/licenses/by-nd/4.0/"
+    commercial_use: true
+
+  odbl-1.0:
+    display_name: "ODbL 1.0"
+    url: "https://opendatacommons.org/licenses/odbl/1-0/"
+    commercial_use: true
+
+  mit:
+    display_name: "MIT License"
+    url: "https://opensource.org/licenses/MIT"
+    commercial_use: true
+
+  # ── Government Open Data Licenses ─────────────────────────────────
+  ogl-3.0:
+    display_name: "OGL v3.0"
+    url: "https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/"
+    commercial_use: true
+
+  ogl-canada:
+    display_name: "Open Government Licence — Canada"
+    url: "https://open.canada.ca/en/open-government-licence-canada"
+    commercial_use: true
+
+  licence-ouverte-2.0:
+    display_name: "Licence Ouverte 2.0"
+    url: "https://www.etalab.gouv.fr/licence-ouverte-open-licence/"
+    commercial_use: true
+
+  iodl-2.0:
+    display_name: "IODL 2.0"
+    url: "https://www.dati.gov.it/content/italian-open-data-license-v20"
+    commercial_use: true
+
+  nlod-2.0:
+    display_name: "NLOD 2.0"
+    url: "https://data.norge.no/nlod/en/2.0"
+    commercial_use: true
+
+  dl-de-2.0:
+    display_name: "Data licence Germany — attribution 2.0"
+    url: "https://www.govdata.de/dl-de/by-2-0"
+    commercial_use: true
+
+  eur-lex:
+    display_name: "EUR-Lex reuse notice"
+    url: "https://eur-lex.europa.eu/content/legal-notice/legal-notice.html"
+    commercial_use: true
+
+  # ── Public Domain by Statute ──────────────────────────────────────
+  pd-us:
+    display_name: "Public domain — 17 U.S.C. 105"
+    url: "https://www.law.cornell.edu/uscode/text/17/105"
+    commercial_use: true
+
+  pd-de:
+    display_name: "Public domain — 5 UrhG"
+    url: "https://www.gesetze-im-internet.de/urhg/__5.html"
+    commercial_use: true
+
+  pd-gov:
+    display_name: "Public domain (government works)"
+    url: null
+    commercial_use: true
+
+  # ── Catch-all Categories ──────────────────────────────────────────
+  ogd:
+    display_name: "Open government data"
+    url: null
+    commercial_use: true
+
+  custom-terms:
+    display_name: "Custom terms of use"
+    url: null
+    commercial_use: null   # per-source; check commercial_use field on each source
+
+  custom-nc:
+    display_name: "Custom non-commercial terms"
+    url: null
+    commercial_use: false
+
+  unverified:
+    display_name: "Unverified — needs research"
+    url: null
+    commercial_use: null

--- a/scripts/generate_licenses_json.py
+++ b/scripts/generate_licenses_json.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+"""
+Generate docs/licenses.json from manifest.yaml and license_registry.yaml.
+
+Produces a static JSON file that makes license data queryable:
+- summary stats (commercial OK, non-commercial, commercial unknown, unverified)
+- per-license breakdown with counts
+- flat source list with license fields for filtering
+
+Usage:
+  python scripts/generate_licenses_json.py
+"""
+
+import json
+import os
+from collections import Counter
+from datetime import datetime, timezone
+
+import yaml
+
+MANIFEST = "manifest.yaml"
+REGISTRY = "license_registry.yaml"
+OUTPUT = "docs/licenses.json"
+
+
+def commercial_use(record, label):
+    """Preserve explicit booleans; absent/null is unknown, never inferred."""
+    value = record.get("commercial_use")
+    if value is not None and type(value) is not bool:
+        raise ValueError(f"{label}: commercial_use must be a boolean or null")
+    return value
+
+
+def main():
+    with open(MANIFEST) as f:
+        manifest = yaml.safe_load(f)
+    with open(REGISTRY) as f:
+        registry = yaml.safe_load(f)["licenses"]
+
+    complete = [s for s in manifest["sources"] if s.get("status") == "complete"]
+
+    # Build source list
+    sources = []
+    for s in sorted(complete, key=lambda x: x["id"]):
+        sources.append({
+            "id": s["id"],
+            "country": str(s.get("country", "")),
+            "name": s.get("name", ""),
+            "license_id": s.get("license_id", ""),
+            "license_name": s.get("license_name", ""),
+            "license_url": s.get("license_url"),
+            "commercial_use": commercial_use(s, s["id"]),
+        })
+
+    # Summary
+    commercial_ok = sum(1 for s in sources if s["commercial_use"] is True)
+    non_commercial = sum(1 for s in sources if s["commercial_use"] is False)
+    commercial_unknown = sum(1 for s in sources if s["commercial_use"] is None)
+    unverified = sum(1 for s in sources if s["license_id"] == "unverified")
+    id_counts = Counter(s["license_id"] for s in sources)
+
+    # Per-license breakdown
+    by_license = {}
+    for lid, count in sorted(id_counts.items(), key=lambda x: -x[1]):
+        reg = registry.get(lid, {})
+        by_license[lid] = {
+            "display_name": reg.get("display_name", lid),
+            "url": reg.get("url"),
+            "commercial_use": commercial_use(reg, f"registry {lid}"),
+            "count": count,
+        }
+
+    output = {
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "summary": {
+            "total_complete": len(sources),
+            "commercial_ok": commercial_ok,
+            "non_commercial": non_commercial,
+            "commercial_unknown": commercial_unknown,
+            "unverified": unverified,
+            "unique_license_ids": len(id_counts),
+        },
+        "by_license": by_license,
+        "sources": sources,
+    }
+
+    os.makedirs(os.path.dirname(OUTPUT), exist_ok=True)
+    with open(OUTPUT, "w") as f:
+        json.dump(output, f, indent=2, ensure_ascii=False)
+
+    print(f"Written {OUTPUT}")
+    print(f"  Sources: {len(sources)}")
+    print(f"  Commercial OK: {commercial_ok}")
+    print(f"  Non-commercial: {non_commercial}")
+    print(f"  Commercial unknown: {commercial_unknown}")
+    print(f"  Unverified: {unverified}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/validate_licenses.py
+++ b/scripts/validate_licenses.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+"""
+Validate license data in manifest.yaml against license_registry.yaml.
+
+Checks:
+  1. Every complete source has license_id, license_name; commercial_use is boolean/null
+  2. license_id exists in the registry
+  3. commercial_use is consistent with the registry
+  4. Tier 1/2 licenses have license_url
+  5. Reports unverified count as warning
+
+Usage:
+  python scripts/validate_licenses.py           # validate
+  python scripts/validate_licenses.py --strict  # fail on unverified sources too
+"""
+
+import sys
+import yaml
+
+MANIFEST = "manifest.yaml"
+REGISTRY = "license_registry.yaml"
+
+# Tier 1/2 licenses that MUST have a license_url
+MUST_HAVE_URL = {
+    "cc0-1.0", "cc-by-3.0", "cc-by-4.0", "cc-by-sa-3.0", "cc-by-sa-4.0",
+    "cc-by-nc", "cc-by-nc-sa", "cc-by-nc-nd", "cc-by-nd-4.0", "odbl-1.0", "mit",
+    "ogl-3.0", "ogl-canada", "licence-ouverte-2.0", "iodl-2.0", "nlod-2.0",
+    "dl-de-2.0", "eur-lex", "pd-us", "pd-de",
+}
+
+
+def main():
+    strict = "--strict" in sys.argv
+
+    with open(MANIFEST) as f:
+        manifest = yaml.safe_load(f)
+    with open(REGISTRY) as f:
+        registry = yaml.safe_load(f)["licenses"]
+
+    valid_ids = set(registry.keys())
+    complete = [s for s in manifest["sources"] if s.get("status") == "complete"]
+
+    errors = []
+    warnings = []
+
+    for source in complete:
+        sid = source["id"]
+
+        # Check required fields
+        if not source.get("license_id"):
+            errors.append(f"{sid}: missing license_id")
+            continue
+
+        lid = source["license_id"]
+
+        if not source.get("license_name"):
+            errors.append(f"{sid}: missing license_name")
+
+        src_cu = source.get("commercial_use")
+        if src_cu is not None and type(src_cu) is not bool:
+            errors.append(f"{sid}: commercial_use must be a boolean or null")
+        elif src_cu is None:
+            warnings.append(f"{sid}: commercial use unknown — needs research")
+
+        # Check registry membership
+        if lid not in valid_ids:
+            errors.append(f"{sid}: unknown license_id '{lid}'")
+            continue
+
+        # Check commercial_use consistency
+        reg_cu = registry[lid].get("commercial_use")
+        if reg_cu is not None and type(reg_cu) is not bool:
+            errors.append(f"{sid}: registry {lid} commercial_use must be a boolean or null")
+        if reg_cu is not None and src_cu is not None and reg_cu != src_cu:
+            errors.append(f"{sid}: commercial_use={src_cu} but registry says {reg_cu} for {lid}")
+
+        # Check URL for tier 1/2
+        if lid in MUST_HAVE_URL and not source.get("license_url"):
+            warnings.append(f"{sid}: {lid} should have license_url")
+
+        # Flag unverified
+        if lid == "unverified":
+            warnings.append(f"{sid}: license unverified — needs research")
+
+    # Report
+    print(f"Validated {len(complete)} complete sources")
+    print(f"  Errors:   {len(errors)}")
+    print(f"  Warnings: {len(warnings)}")
+
+    if errors:
+        print("\n--- ERRORS ---")
+        for e in errors:
+            print(f"  {e}")
+
+    if warnings:
+        print(f"\n--- WARNINGS ({len(warnings)}) ---")
+        for w in warnings:
+            print(f"  {w}")
+
+    # Summary
+    from collections import Counter
+    ids = Counter(s.get("license_id") for s in complete if s.get("license_id"))
+    nc = sum(1 for s in complete if s.get("commercial_use") is False)
+    ok = sum(1 for s in complete if s.get("commercial_use") is True)
+    unknown = sum(1 for s in complete if s.get("commercial_use") is None)
+    unv = sum(1 for s in complete if s.get("license_id") == "unverified")
+    print(f"\n--- Summary ---")
+    print(f"  Unique license IDs: {len(ids)}")
+    print(f"  Commercial use OK:  {ok}")
+    print(f"  Non-commercial:     {nc}")
+    print(f"  Commercial unknown: {unknown}")
+    print(f"  Unverified:         {unv}")
+
+    if errors:
+        sys.exit(1)
+    if strict and unv > 0:
+        print(f"\n--strict: failing due to {unv} unverified sources")
+        sys.exit(1)
+
+    print("\nPASS")
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_license_inventory.py
+++ b/tests/test_license_inventory.py
@@ -1,0 +1,80 @@
+"""Small, offline fixtures for the published license inventory contract."""
+import json
+
+import pytest
+import yaml
+
+from scripts import generate_licenses_json as generator
+
+
+def configure(tmp_path, monkeypatch, sources, registry=None):
+    manifest = tmp_path / "manifest.yaml"
+    taxonomy = tmp_path / "license_registry.yaml"
+    output = tmp_path / "docs" / "licenses.json"
+    manifest.write_text(yaml.safe_dump({"sources": sources}))
+    taxonomy.write_text(yaml.safe_dump({"licenses": registry or {}}))
+    monkeypatch.setattr(generator, "MANIFEST", str(manifest))
+    monkeypatch.setattr(generator, "REGISTRY", str(taxonomy))
+    monkeypatch.setattr(generator, "OUTPUT", str(output))
+    return output
+
+
+def test_commercial_use_is_tristate_without_guessing_or_dedup(tmp_path, monkeypatch):
+    sources = [
+        {"id": "ZZ/Missing", "status": "complete", "license_id": "open"},
+        {"id": "ZZ/Null", "status": "complete", "commercial_use": None},
+        {"id": "ZZ/True", "status": "complete", "commercial_use": True},
+        {"id": "ZZ/False", "status": "complete", "commercial_use": False},
+        {"id": "ZZ/True", "status": "complete", "commercial_use": True},
+        {"id": "ZZ/Planned", "status": "planned", "commercial_use": True},
+    ]
+    output = configure(tmp_path, monkeypatch, sources, {"open": {"commercial_use": True}})
+    generator.main()
+    data = json.loads(output.read_text())
+    assert [(s["id"], s["commercial_use"]) for s in data["sources"]] == [
+        ("ZZ/False", False), ("ZZ/Missing", None), ("ZZ/Null", None),
+        ("ZZ/True", True), ("ZZ/True", True),
+    ]
+    assert data["summary"] == {
+        "total_complete": 5, "commercial_ok": 2, "non_commercial": 1,
+        "commercial_unknown": 2, "unverified": 0, "unique_license_ids": 2,
+    }
+    assert data["sources"][1]["license_name"] == ""
+    assert data["sources"][1]["license_url"] is None
+    assert data["by_license"][""]["commercial_use"] is None
+
+
+@pytest.mark.parametrize("value", ["true", "false", "", 0, 1, [], {}])
+@pytest.mark.parametrize("location", ["source", "registry"])
+def test_invalid_commercial_use_fails_without_overwriting(tmp_path, monkeypatch, value, location):
+    source = {"id": "ZZ/Test", "status": "complete", "license_id": "custom"}
+    registry = {"custom": {}}
+    (source if location == "source" else registry["custom"])["commercial_use"] = value
+    output = configure(tmp_path, monkeypatch, [source], registry)
+    output.parent.mkdir()
+    output.write_text("previous valid inventory")
+    with pytest.raises(ValueError, match="commercial_use"):
+        generator.main()
+    assert output.read_text() == "previous valid inventory"
+
+
+@pytest.mark.parametrize("value", ["true", "false", "", 0, 1, [], {}, None, True, False, "missing"])
+def test_validator_accepts_only_boolean_or_unknown(tmp_path, monkeypatch, capsys, value):
+    from scripts import validate_licenses as validator
+
+    source = {"id": "ZZ/Test", "status": "complete", "license_id": "custom",
+              "license_name": "Custom"}
+    if value != "missing":
+        source["commercial_use"] = value
+    configure(tmp_path, monkeypatch, [source], {"custom": {"commercial_use": None}})
+    monkeypatch.setattr(validator, "MANIFEST", generator.MANIFEST)
+    monkeypatch.setattr(validator, "REGISTRY", generator.REGISTRY)
+    monkeypatch.setattr("sys.argv", ["validate_licenses.py"])
+    with pytest.raises(SystemExit) as result:
+        validator.main()
+    valid = value is None or type(value) is bool or value == "missing"
+    assert result.value.code == (0 if valid else 1)
+    report = capsys.readouterr().out
+    if value is None or value == "missing":
+        assert "Commercial use OK:  0" in report
+        assert "Commercial unknown: 1" in report

--- a/tests/test_license_refresh.py
+++ b/tests/test_license_refresh.py
@@ -1,0 +1,64 @@
+"""Exercise the refresh CLI in a synthetic checkout, without data or credentials."""
+import json
+import os
+from pathlib import Path
+import shutil
+import subprocess
+import sys
+
+import pytest
+import yaml
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+@pytest.mark.parametrize("failure", [None, "missing-generator", "missing-registry", "invalid-type"])
+def test_dashboard_refresh_requires_license_generation(tmp_path, failure):
+    shutil.copyfile(ROOT / "generate_dashboard.py", tmp_path / "generate_dashboard.py")
+    scripts = tmp_path / "scripts"
+    scripts.mkdir()
+    if failure != "missing-generator" and (ROOT / "scripts/generate_licenses_json.py").exists():
+        shutil.copyfile(ROOT / "scripts/generate_licenses_json.py", scripts / "generate_licenses_json.py")
+    source = {"id": "ZZ/Test", "country": "ZZ", "status": "complete"}
+    if failure == "invalid-type":
+        source["commercial_use"] = "false"
+    (tmp_path / "manifest.yaml").write_text(yaml.safe_dump({"sources": [source]}))
+    if failure != "missing-registry":
+        (tmp_path / "license_registry.yaml").write_text("licenses: {}\n")
+    docs = tmp_path / "docs"
+    docs.mkdir()
+    (docs / "status.json").write_text("previous status")
+    (docs / "licenses.json").write_text("previous licenses")
+    env = {k: v for k, v in os.environ.items()
+           if k not in {"NEON_DATABASE_URL", "DATABASE_URL", "PYTHONPATH"}}
+    env["HOME"] = str(tmp_path)
+    result = subprocess.run([sys.executable, "generate_dashboard.py"], cwd=tmp_path,
+                            env=env, capture_output=True, text=True, timeout=15)
+    if failure:
+        assert result.returncode != 0, result.stdout + result.stderr
+        assert (docs / "status.json").read_text() == "previous status"
+        assert (docs / "licenses.json").read_text() == "previous licenses"
+    else:
+        assert result.returncode == 0, result.stdout + result.stderr
+        assert json.loads((docs / "status.json").read_text())["summary"]["complete"] == 1
+        inventory = json.loads((docs / "licenses.json").read_text())
+        assert inventory["sources"][0]["commercial_use"] is None
+        assert inventory["summary"]["commercial_unknown"] == 1
+
+
+def test_refresh_stages_both_outputs_and_has_generator_dependencies():
+    assert (ROOT / "scripts/generate_licenses_json.py").is_file()
+    registry = yaml.safe_load((ROOT / "license_registry.yaml").read_text())
+    assert isinstance(registry["licenses"], dict)
+    workflow = yaml.safe_load((ROOT / ".github/workflows/refresh-dashboard.yml").read_text())
+    runs = "\n".join(step.get("run", "") for step in workflow["jobs"]["refresh"]["steps"])
+    assert "pyyaml" in runs.lower()
+    assert "git add docs/status.json docs/licenses.json" in runs
+    # PyYAML's YAML 1.1 loader treats the GitHub 'on' key as True.
+    triggers = workflow.get("on", workflow.get(True))
+    if "push" in triggers:
+        paths = triggers["push"]["paths"]
+        for required in ("manifest.yaml", "license_registry.yaml", "generate_dashboard.py",
+                         "scripts/generate_licenses_json.py", ".github/workflows/refresh-dashboard.yml"):
+            assert required in paths
+        assert "schedule" in triggers  # bot-token pushes do not dispatch push workflows


### PR DESCRIPTION
## Summary
- Add the self-contained generator, validator, and public-safe license taxonomy (generic display names, canonical public URLs, boolean/null commercial-use classification only; no credentials or private source metadata).
- Preserve true/false and emit null for unknown permission; count unknown separately and reject malformed types, without inferring permissions or deduplicating sources.
- Fail before dashboard status writes if license generation fails. Extend refresh input triggers, add a two-hour schedule, and stage both status.json and licenses.json after successful generation.
- Add contract documentation, offline fixtures, and PR CI. No manifest/source metadata, generated JSON, or CLAUDE.md changes.

## Verification
- `uv run --with pytest --with pyyaml python -m pytest tests/test_license_inventory.py tests/test_license_refresh.py -q`: **31 passed**.
- `git diff --cached --check`: clean before commit.
- Read-only validation still exits 1 with **21 existing metadata errors and 28 warnings** across 2,111 complete entries (1,924 true / 165 false / 22 unknown).
- Existing manifest duplicate **CA/ON-OSC appears twice** and is preserved, not fixed. Counts are entries, not distinct IDs.

## Explicitly NOT FIXED
**Private-to-public SOURCE manifest synchronization.** No exporter/sync implementation is included. The schedule only regenerates output from the current checked-in public manifest; it does NOT import newer sources. An external source synchronization integration remains unverified and unresolved.

Related earlier license work was not reused because it converted unknown permissions to false; this request requires null and no data edits.

No merge, manual refresh, or data publication performed.